### PR TITLE
added a .zenodo.json file to control Zenodo's release metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,20 @@
+{
+    "description": "Web frontend to the Fast Radio Burst Catalogue",
+    "license": "Apache-2.0",
+    "title": "frbcatdb-web",
+    "upload_type": "software",
+    "creators": [
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Haren, Ronald"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+        "Fast Radio Bursts",
+        "FRB",
+        "Apertif",
+        "radio astronomy",
+        "VOEvent"
+    ]
+}


### PR DESCRIPTION
Hey I'm experimenting a bit with controlling the metadata that gets attached to your releases on Zenodo. In this PR, I've added a new file ``.zenodo.json`` which now includes the contributors from https://github.com/AA-ALERT/frbcat-web/graphs/contributors as ``creators``. If you also want to include people who make issues and such, there is another field ``contributors`` you can add to the ``.zenodo.json``. Items you include there can have an attribute ``type`` which you can set to ``Other`` or another type from the controlled vocabulary [ContactPerson, DataCollector, DataCurator, DataManager, Editor, Researcher, RightsHolder, Sponsor, Other]. 

Anyway long story short, with this ``.zenodo.json`` file, your release process should be less painful.
-Jurriaan